### PR TITLE
Usar callback para console.log en app.listen

### DIFF
--- a/SADA/server.js
+++ b/SADA/server.js
@@ -68,5 +68,6 @@ app.use(flash()); // use connect-flash for flash messages stored in session
 require('./app/routes.js')(app, passport, connection, transporter,dbconfig); //pass in our app and fully configured passport
 
 // launch ======================================================================
-app.listen(port);
-console.log('Running on port: ' + port);
+app.listen(port, function() {
+	console.log('Running on port: ' + port);
+});


### PR DESCRIPTION
El cambio garantiza que el mensaje de 'Escuchando en el purto X' se ejecute sólo una vez el servidor se haya encendido satisfactoriamente.